### PR TITLE
Implement a bounds-based location filter

### DIFF
--- a/Trippy.xcodeproj/project.pbxproj
+++ b/Trippy.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		F079EF98289B1F6100F9BAA7 /* YelpAPIManager.m in Sources */ = {isa = PBXBuildFile; fileRef = F079EF97289B1F6100F9BAA7 /* YelpAPIManager.m */; };
 		F079EF9B289B262300F9BAA7 /* YelpBusiness.m in Sources */ = {isa = PBXBuildFile; fileRef = F079EF9A289B262300F9BAA7 /* YelpBusiness.m */; };
 		F079EF9E289B2A8300F9BAA7 /* YelpBusinessCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F079EF9D289B2A8300F9BAA7 /* YelpBusinessCell.m */; };
+		F079EFA3289DBAB100F9BAA7 /* main.js in Resources */ = {isa = PBXBuildFile; fileRef = F079EFA2289DBAB100F9BAA7 /* main.js */; };
 		F07D030C288EFCE30049F355 /* RouteOption.m in Sources */ = {isa = PBXBuildFile; fileRef = F07D030B288EFCE30049F355 /* RouteOption.m */; };
 		F07D030F288F07260049F355 /* ItineraryItemCell.m in Sources */ = {isa = PBXBuildFile; fileRef = F07D030E288F07260049F355 /* ItineraryItemCell.m */; };
 		F07D0312288F07540049F355 /* ViewItineraryViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = F07D0311288F07540049F355 /* ViewItineraryViewController.m */; };
@@ -127,6 +128,7 @@
 		F079EF9A289B262300F9BAA7 /* YelpBusiness.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = YelpBusiness.m; path = Trippy/Models/YelpBusiness.m; sourceTree = "<group>"; };
 		F079EF9C289B2A8300F9BAA7 /* YelpBusinessCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = YelpBusinessCell.h; sourceTree = "<group>"; };
 		F079EF9D289B2A8300F9BAA7 /* YelpBusinessCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = YelpBusinessCell.m; sourceTree = "<group>"; };
+		F079EFA2289DBAB100F9BAA7 /* main.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = main.js; sourceTree = "<group>"; };
 		F07D030A288EFCE30049F355 /* RouteOption.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RouteOption.h; path = Trippy/Models/RouteOption.h; sourceTree = "<group>"; };
 		F07D030B288EFCE30049F355 /* RouteOption.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RouteOption.m; path = Trippy/Models/RouteOption.m; sourceTree = "<group>"; };
 		F07D030D288F07260049F355 /* ItineraryItemCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ItineraryItemCell.h; sourceTree = "<group>"; };
@@ -306,6 +308,14 @@
 			path = "Explore Tab";
 			sourceTree = "<group>";
 		};
+		F079EFA1289DBA9800F9BAA7 /* ParseCloud */ = {
+			isa = PBXGroup;
+			children = (
+				F079EFA2289DBAB100F9BAA7 /* main.js */,
+			);
+			path = ParseCloud;
+			sourceTree = "<group>";
+		};
 		F0C75FA5287CC1BA0015BB74 /* Collections Tab */ = {
 			isa = PBXGroup;
 			children = (
@@ -394,6 +404,7 @@
 		F0F335722874A0E700470507 /* Trippy */ = {
 			isa = PBXGroup;
 			children = (
+				F079EFA1289DBA9800F9BAA7 /* ParseCloud */,
 				F079EF842899872900F9BAA7 /* External Libraries */,
 				F079EF732898797C00F9BAA7 /* Assets */,
 				F0F6581228887FE000C04AB0 /* Handlers */,
@@ -656,6 +667,7 @@
 				F079EF6F28986D6D00F9BAA7 /* paper_plane.gif in Resources */,
 				F0C75F6D287642C10015BB74 /* Keys.plist in Resources */,
 				F0F335832874A0EB00470507 /* LaunchScreen.storyboard in Resources */,
+				F079EFA3289DBAB100F9BAA7 /* main.js in Resources */,
 				F0F335802874A0EB00470507 /* Assets.xcassets in Resources */,
 				F0F3357E2874A0E700470507 /* Main.storyboard in Resources */,
 			);
@@ -1210,6 +1222,7 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCVersionGroup section */
 		F0342E1C28946111006717CB /* DataModel.xcdatamodeld */ = {
 			isa = XCVersionGroup;

--- a/Trippy.xcworkspace/xcuserdata/catherinelu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Trippy.xcworkspace/xcuserdata/catherinelu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,38 +3,4 @@
    uuid = "DE0E8B21-8608-4662-BEC0-69B69F45FD7C"
    type = "0"
    version = "2.0">
-   <Breakpoints>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "89D56097-02E1-4F3B-91E4-E7A0F4786A38"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Trippy/Handlers/CacheDataHandler.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "122"
-            endingLineNumber = "122"
-            landmarkName = "-updateItinerary:"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "34522B71-4958-4502-8225-F28F9E18B0E9"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Trippy/Handlers/GeoDataHandler.m"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "28"
-            endingLineNumber = "28"
-            landmarkName = "-fetchAverageItineraryRadius:"
-            landmarkType = "7">
-         </BreakpointContent>
-      </BreakpointProxy>
-   </Breakpoints>
 </Bucket>

--- a/Trippy.xcworkspace/xcuserdata/catherinelu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Trippy.xcworkspace/xcuserdata/catherinelu.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -3,4 +3,38 @@
    uuid = "DE0E8B21-8608-4662-BEC0-69B69F45FD7C"
    type = "0"
    version = "2.0">
+   <Breakpoints>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "89D56097-02E1-4F3B-91E4-E7A0F4786A38"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Trippy/Handlers/CacheDataHandler.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "122"
+            endingLineNumber = "122"
+            landmarkName = "-updateItinerary:"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "34522B71-4958-4502-8225-F28F9E18B0E9"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "Trippy/Handlers/GeoDataHandler.m"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "28"
+            endingLineNumber = "28"
+            landmarkName = "-fetchAverageItineraryRadius:"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+   </Breakpoints>
 </Bucket>

--- a/Trippy/Handlers/CacheDataHandler.m
+++ b/Trippy/Handlers/CacheDataHandler.m
@@ -114,7 +114,7 @@
             obj[@"staticMap"] = [ParseUtils pfFileFromImage:it.staticMap name:@"img"];
             obj[@"directionsJson"] = [ParseUtils pfFileFromDict:[it toRouteDictionary] name:@"directions"];
             obj[@"isFavorited"] = [NSNumber numberWithBool:it.isFavorited];
-            CLLocationCoordinate2D center = [MapUtils getCenterOfBounds:it.bounds];
+            CLLocationCoordinate2D center = [it getCentroid];
             PFGeoPoint *coord = [[PFGeoPoint alloc] init];
             coord.latitude = center.latitude;
             coord.longitude = center.longitude;

--- a/Trippy/Handlers/CacheDataHandler.m
+++ b/Trippy/Handlers/CacheDataHandler.m
@@ -8,7 +8,6 @@
 #import "CacheDataHandler.h"
 #import "ParseUtils.h"
 #import "PriceUtils.h"
-#import "MapUtils.h"
 #import "Parse/Parse.h"
 #import "Location.h"
 #import "LocationCollection.h"
@@ -119,7 +118,7 @@
             coord.latitude = center.latitude;
             coord.longitude = center.longitude;
             obj[@"startCoord"] = coord;
-            obj[@"radius"] = @([MapUtils getRadiusOfBounds:it.bounds] / 1000);
+            obj[@"radius"] = [it getRadius];
             [obj saveInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
                 if (succeeded) {
                     __strong CacheDataHandler *strongSelf = weakSelf;

--- a/Trippy/Handlers/CacheDataHandler.m
+++ b/Trippy/Handlers/CacheDataHandler.m
@@ -8,6 +8,7 @@
 #import "CacheDataHandler.h"
 #import "ParseUtils.h"
 #import "PriceUtils.h"
+#import "MapUtils.h"
 #import "Parse/Parse.h"
 #import "Location.h"
 #import "LocationCollection.h"
@@ -113,6 +114,12 @@
             obj[@"staticMap"] = [ParseUtils pfFileFromImage:it.staticMap name:@"img"];
             obj[@"directionsJson"] = [ParseUtils pfFileFromDict:[it toRouteDictionary] name:@"directions"];
             obj[@"isFavorited"] = [NSNumber numberWithBool:it.isFavorited];
+            CLLocationCoordinate2D center = [MapUtils getCenterOfBounds:it.bounds];
+            PFGeoPoint *coord = [[PFGeoPoint alloc] init];
+            coord.latitude = center.latitude;
+            coord.longitude = center.longitude;
+            obj[@"startCoord"] = coord;
+            obj[@"radius"] = @([MapUtils getRadiusOfBounds:it.bounds] / 1000);
             [obj saveInBackgroundWithBlock:^(BOOL succeeded, NSError * _Nullable error) {
                 if (succeeded) {
                     __strong CacheDataHandler *strongSelf = weakSelf;

--- a/Trippy/Handlers/GeoDataHandler.m
+++ b/Trippy/Handlers/GeoDataHandler.m
@@ -22,42 +22,55 @@
 
 @implementation GeoDataHandler
 
+- (void) fetchAverageItineraryRadius:(void (^)(NSNumber *result, NSError *))completion {
+    [PFCloud callFunctionInBackground:@"averageItineraryRadius" withParameters:@{} block:^(id  _Nullable object, NSError * _Nullable error) {
+        if (object) {
+            completion(object, nil);
+        } else {
+            completion(nil, error);
+        }
+    }];
+}
+
 - (void) fetchItinerariesByCoordinate:(CLLocationCoordinate2D)coord rangeInKm:(double)rangeInKm {
     if (![NetworkManager shared].isConnected || self.isFetchingItineraryByCoordinate) {
         return;
     }
     self.isFetchingItineraryByCoordinate = YES;
-    PFGeoPoint *geopoint = [[PFGeoPoint alloc] init];
-    geopoint.latitude = coord.latitude;
-    geopoint.longitude = coord.longitude;
-    PFQuery *query = [PFQuery queryWithClassName:@"Itinerary"];
-    [query setLimit:QUERY_LIMIT];
-    [query whereKey:@"startCoord" nearGeoPoint:geopoint withinKilometers:rangeInKm];
-    [query whereKey:@"createdBy" notEqualTo:[PFUser currentUser]];
     __weak GeoDataHandler *weakSelf = self;
-    [query findObjectsInBackgroundWithBlock:^(NSArray * _Nullable objects, NSError * _Nullable error) {
-        __strong GeoDataHandler *strongSelf = weakSelf;
-        if (error) {
-            [strongSelf.delegate generalRequestFail:error];
-        } else {
-            strongSelf.itineraryFetchCount = objects.count;
-            if (objects.count == 0) {
-                [strongSelf.delegate didAddAll];
+    [self fetchAverageItineraryRadius:^(NSNumber *result, NSError *) {
+        double avgDist = result ? [result doubleValue] : 0;
+        PFGeoPoint *geopoint = [[PFGeoPoint alloc] init];
+        geopoint.latitude = coord.latitude;
+        geopoint.longitude = coord.longitude;
+        PFQuery *query = [PFQuery queryWithClassName:@"Itinerary"];
+        [query setLimit:QUERY_LIMIT];
+        [query whereKey:@"startCoord" nearGeoPoint:geopoint withinKilometers:(rangeInKm + avgDist)];
+        [query whereKey:@"createdBy" notEqualTo:[PFUser currentUser]];
+        [query findObjectsInBackgroundWithBlock:^(NSArray * _Nullable objects, NSError * _Nullable error) {
+            __strong GeoDataHandler *strongSelf = weakSelf;
+            if (error) {
+                [strongSelf.delegate generalRequestFail:error];
+            } else {
+                strongSelf.itineraryFetchCount = objects.count;
+                if (objects.count == 0) {
+                    [strongSelf.delegate didAddAll];
+                }
+                for(PFObject *obj in objects) {
+                    [ParseUtils itineraryFromPFObj:obj completion:^(Itinerary * _Nonnull itinerary, NSError * _Nonnull) {
+                        __strong GeoDataHandler *strongSelf = weakSelf;
+                        if(error) {
+                            [strongSelf.delegate generalRequestFail:error];
+                        } else {
+                            itinerary.isOffline = NO;
+                            [strongSelf.delegate addFetchedNearbyItinerary:itinerary];
+                        }
+                        [strongSelf decrementItineraryFetchCount];
+                    }];
+                }
             }
-            for(PFObject *obj in objects) {
-                [ParseUtils itineraryFromPFObj:obj completion:^(Itinerary * _Nonnull itinerary, NSError * _Nonnull) {
-                    __strong GeoDataHandler *strongSelf = weakSelf;
-                    if(error) {
-                        [strongSelf.delegate generalRequestFail:error];
-                    } else {
-                        itinerary.isOffline = NO;
-                        [strongSelf.delegate addFetchedNearbyItinerary:itinerary];
-                    }
-                    [strongSelf decrementItineraryFetchCount];
-                }];
-            }
-        }
-        strongSelf.isFetchingItineraryByCoordinate = NO;
+            strongSelf.isFetchingItineraryByCoordinate = NO;
+        }];
     }];
 }
 

--- a/Trippy/Models/Itinerary.h
+++ b/Trippy/Models/Itinerary.h
@@ -71,6 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSNumber *)getTotalDistance;
 - (NSNumber *)getTotalCost:(BOOL)includeAll;
 - (CLLocationCoordinate2D)getCentroid;
+- (NSNumber *)getRadius;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Trippy/Models/Itinerary.h
+++ b/Trippy/Models/Itinerary.h
@@ -70,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDate *)computeDeparture:(int)waypointIndex;
 - (NSNumber *)getTotalDistance;
 - (NSNumber *)getTotalCost:(BOOL)includeAll;
+- (CLLocationCoordinate2D)getCentroid;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Trippy/Models/Itinerary.m
+++ b/Trippy/Models/Itinerary.m
@@ -202,6 +202,10 @@
     return @([PriceUtils computeTotalCost:self locations:locs omitWaypoints:@[]]);
 }
 
+- (NSNumber *)getRadius {
+    return @([MapUtils getRadiusOfBounds:self.bounds] / 1000); // in km
+}
+
 - (CLLocationCoordinate2D)getCentroid {
     int count = 1;
     double lat = self.originLocation.coord.latitude;

--- a/Trippy/Models/Itinerary.m
+++ b/Trippy/Models/Itinerary.m
@@ -202,4 +202,16 @@
     return @([PriceUtils computeTotalCost:self locations:locs omitWaypoints:@[]]);
 }
 
+- (CLLocationCoordinate2D)getCentroid {
+    int count = 1;
+    double lat = self.originLocation.coord.latitude;
+    double lon = self.originLocation.coord.longitude;
+    for (Location *loc in [self getOrderedLocations]) {
+        lat += loc.coord.latitude;
+        lon += loc.coord.longitude;
+        count += 1;
+    }
+    return CLLocationCoordinate2DMake(lat / count, lon / count);
+}
+
 @end

--- a/Trippy/ParseCloud/main.js
+++ b/Trippy/ParseCloud/main.js
@@ -1,0 +1,9 @@
+Parse.Cloud.define("averageItineraryRadius", async (request) => {
+  const query = new Parse.Query("Itinerary");
+  const results = await query.find();
+  let sum = 0;
+  for (let i = 0; i < results.length; ++i) {
+    sum += results[i].get("radius");
+  }
+  return sum / results.length;
+});

--- a/Trippy/Utils/MapUtils.h
+++ b/Trippy/Utils/MapUtils.h
@@ -31,6 +31,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSString *)generateMatrixApiUrl:(LocationCollection *)collection
                             origin:(Location *)origin
                      departureTime:(NSDate *)departureTime;
++ (CLLocationCoordinate2D)getCenterOfBounds:(GMSCoordinateBounds *)bounds;
++ (double)getRadiusOfBounds:(GMSCoordinateBounds *)bounds;
 + (double)metersToMiles:(int)meters;
 + (int)milesToMeters:(double)miles;
 @end

--- a/Trippy/Utils/MapUtils.m
+++ b/Trippy/Utils/MapUtils.m
@@ -109,4 +109,16 @@
     return inMeters;
 }
 
++ (CLLocationCoordinate2D)getCenterOfBounds:(GMSCoordinateBounds *)bounds {
+    double lat1 = bounds.northEast.latitude;
+    double lat2 = bounds.southWest.latitude;
+    double lon1 = bounds.northEast.longitude;
+    double lon2 = bounds.southWest.longitude;
+    return CLLocationCoordinate2DMake((lat1 + lat2) / 2, (lon1 + lon2) / 2);
+}
+
++ (double)getRadiusOfBounds:(GMSCoordinateBounds *)bounds {
+    return GMSGeometryDistance(bounds.northEast, bounds.southWest) / 2;
+}
+
 @end

--- a/Trippy/Utils/ParseUtils.m
+++ b/Trippy/Utils/ParseUtils.m
@@ -248,7 +248,7 @@
                 obj[@"mileageConstraint"] = it.mileageConstraint;
                 obj[@"budgetConstraint"] = it.budgetConstraint;
                 obj[@"isFavorited"] = [NSNumber numberWithBool:it.isFavorited];
-                CLLocationCoordinate2D center = [MapUtils getCenterOfBounds:it.bounds];
+                CLLocationCoordinate2D center = [it getCentroid];
                 PFGeoPoint *coord = [[PFGeoPoint alloc] init];
                 coord.latitude = center.latitude;
                 coord.longitude = center.longitude;

--- a/Trippy/Utils/ParseUtils.m
+++ b/Trippy/Utils/ParseUtils.m
@@ -10,6 +10,7 @@
 #import "Itinerary.h"
 #import "LocationCollection.h"
 #import "Location.h"
+#import "MapUtils.h"
 
 @implementation ParseUtils
 
@@ -22,7 +23,7 @@
 }
 
 + (NSArray *)getItineraryKeys {
-    return @[@"directionsJson", @"createdAt", @"name", @"createdBy", @"origin", @"startCoord", @"sourceCollection", @"departure", @"mileageConstraint", @"budgetConstraint", @"isFavorited", @"staticMap"];
+    return @[@"directionsJson", @"createdAt", @"name", @"createdBy", @"origin", @"startCoord", @"radius", @"sourceCollection", @"departure", @"mileageConstraint", @"budgetConstraint", @"isFavorited", @"staticMap"];
 }
 
 + (NSString *)getLoggedInUsername {
@@ -230,7 +231,6 @@
             [self pfObjFromLocation:it.originLocation completion:^(PFObject * _Nonnull newObj, NSError * _Nonnull) {
                 if (obj) {
                     obj[@"origin"] = newObj;
-                    obj[@"startCoord"] = [newObj valueForKey:@"coord"];
                 }
                 dispatch_group_leave(group);
             }];
@@ -248,6 +248,12 @@
                 obj[@"mileageConstraint"] = it.mileageConstraint;
                 obj[@"budgetConstraint"] = it.budgetConstraint;
                 obj[@"isFavorited"] = [NSNumber numberWithBool:it.isFavorited];
+                CLLocationCoordinate2D center = [MapUtils getCenterOfBounds:it.bounds];
+                PFGeoPoint *coord = [[PFGeoPoint alloc] init];
+                coord.latitude = center.latitude;
+                coord.longitude = center.longitude;
+                obj[@"startCoord"] = coord;
+                obj[@"radius"] = @([MapUtils getRadiusOfBounds:it.bounds] / 1000);
                 if (it.staticMap) {
                     obj[@"staticMap"] = [self pfFileFromImage:it.staticMap name:@"img"];
                 } else {

--- a/Trippy/Utils/ParseUtils.m
+++ b/Trippy/Utils/ParseUtils.m
@@ -10,7 +10,6 @@
 #import "Itinerary.h"
 #import "LocationCollection.h"
 #import "Location.h"
-#import "MapUtils.h"
 
 @implementation ParseUtils
 
@@ -253,7 +252,7 @@
                 coord.latitude = center.latitude;
                 coord.longitude = center.longitude;
                 obj[@"startCoord"] = coord;
-                obj[@"radius"] = @([MapUtils getRadiusOfBounds:it.bounds] / 1000);
+                obj[@"radius"] = [it getRadius];
                 if (it.staticMap) {
                     obj[@"staticMap"] = [self pfFileFromImage:it.staticMap name:@"img"];
                 } else {

--- a/Trippy/Views/SelectableMap.m
+++ b/Trippy/Views/SelectableMap.m
@@ -120,6 +120,7 @@
     }
     
     GMSCameraPosition *pos = [GMSCameraPosition cameraWithLatitude:location.latitude longitude:location.longitude zoom:self.mapView.camera.zoom];
+
     if(animate) {
         [self.mapView animateToCameraPosition:pos];
     }


### PR DESCRIPTION
Implemented a more sophisticated location filter for "Trips Near You" feature on Explore tab. Instead of a static constraint on their starting locations, itineraries are displayed if the centroid of their locations is within a calculated range equal to 50km plus the average radius of all itineraries created, which is computed in the background on Parse Cloud.

(no media demo since it looks effectively the same, but have verified the calculations manually)